### PR TITLE
Guaranteed to have a space character between the LABEL and ADDRESS value...

### DIFF
--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -742,7 +742,7 @@ void Compiler::WriteSummary(std::ostream& out)
 			if(j->first.empty() || !isalpha(j->first.at(0)))
 				continue;
 
-			out << left << setw(29) << j->first;
+			out << left << setw(28) << j->first << ' ';
 			out << "$" << setbase(16) << j->second->GetTarget() << endl;
 		}
 		out << "-----------------------------------------------------------------" << endl;

--- a/src/symboltable.cpp
+++ b/src/symboltable.cpp
@@ -219,7 +219,7 @@ string SymbolTable::JumpsTable() const
 	ss << "LABEL                    ADDRESS" << endl;
 	map<string,Anchor*>::const_iterator i;
 	for(i = jumps.begin(); i != jumps.end(); ++i) {
-		ss << setw(25) << std::left << i->first;
+		ss << setw(24) << std::left << i->first << ' ';
 		ss << setbase(16) << i->second->GetTarget() << endl;
 	}
 	return ss.str();


### PR DESCRIPTION
...s in the compilation summary. Previously if a label was long there would be output like:

```
this_identifier_is_looooooooooooong$f10000
```

With this fix, the new output is:

```
this_identifier_is_looooooooooooong $f10000
```
