### PR TITLE
Tried to get this thing to work on MacOS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ source_files = [os.path.join("src", x) for x in os.listdir("src") if x.lower().e
 extra_compile_args = []
 extra_link_args = []
 
-if platform.system() == "Linux":
+if platform.system() == "Linux" or platform.system() == "Darwin":
       extra_compile_args = ["-std=c++14"]
       extra_link_args = ["-lstdc++fs"]
 


### PR DESCRIPTION
added:
 or platform.system() == "Darwin"
 as a check to see if extra arguments should be used.